### PR TITLE
Implement KIND-based Kubernetes component test

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -48,3 +48,22 @@ jobs:
     - name: Run the component tests
       run: . component-test.sh
       working-directory: ./test
+
+  kubernetes-component-test:
+    runs-on: ubuntu-latest
+    needs: test-code
+    steps:
+    - name: Download workspace
+      uses: actions/download-artifact@v1
+      with:
+        name: workspace
+        path: .
+    - name: Prepare KIND cluster
+      run: . setup-kind.sh
+      working-directory: ./test
+    - name: Kubernetes Component Test
+      run: . k8s-component-test.sh
+      working-directory: ./test
+    - name: Teardown KIND cluster
+      run: . teardown-kind.sh
+      working-directory: ./test

--- a/test/k8s-component-test-job.yaml
+++ b/test/k8s-component-test-job.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: component-test
+spec:
+  template:
+    metadata:
+      labels:
+        type: component-test
+    spec:
+      containers:
+      - name: component-test
+        image: age-test
+        imagePullPolicy: Never
+        env:
+        - name: SERVICE_URL
+          value: http://age:8080
+        - name: METRICS_URL
+          value: http://age:8080/metrics
+      restartPolicy: Never

--- a/test/k8s-component-test.sh
+++ b/test/k8s-component-test.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+set -xe
+
+helm install --wait age ../helm/age --set image.repository=age --set image.tag=latest --set image.pullPolicy=Never
+
+kubectl get po,svc
+
+kubectl apply -f k8s-component-test-job.yaml
+
+kubectl wait --for=condition=complete --timeout=1m job/component-test
+
+kubectl logs -l type=component-test
+
+SUCCESS=$(kubectl get job component-test -o jsonpath='{.status.succeeded}')
+
+if [ $SUCCESS != '1' ]; then exit 1; fi
+
+echo "Component test succesful"

--- a/test/setup-kind.sh
+++ b/test/setup-kind.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+set -xe
+
+sudo curl -sL https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-Linux-amd64 -o /usr/local/bin/kind
+sudo chmod 755 /usr/local/bin//kind
+
+sudo curl -sL https://storage.googleapis.com/kubernetes-release/release/v1.17.4/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
+#sudo chmod 755 /usr/local/bin//kubectl
+
+curl -LO https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
+tar -xzf helm-v3.1.2-linux-amd64.tar.gz
+sudo mv linux-amd64/helm /usr/local/bin/
+rm -rf helm-v3.1.2-linux-amd64.tar.gz
+
+kind version
+kubectl version --client=true
+helm version
+
+kind -q create cluster --wait 10m
+
+kubectl get nodes
+
+docker build -t age:latest ../app
+docker build -t age-test:latest .
+kind load docker-image age:latest
+kind load docker-image age-test:latest

--- a/test/teardown-kind.sh
+++ b/test/teardown-kind.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+set -xe
+
+kind -q delete cluster


### PR DESCRIPTION
Use KIND to create an on-demand cluster, deploy the helm chart with Helm, deploy the test container with a Kubernetes job, wait for test job to finish, fail or pass depending on status of job.